### PR TITLE
Support multiple packages in one project

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Compile
+        run: npm run compile
+
+      - name: Run tests
+        run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
-# viash-vscode unreleased
+# viash-vscode v0.3.0
 
+## NEW FUNCTIONALITY
+
+* Support for multiple Viash packages in a workspace, each with its own `viash_version` (PR #39).
+
+* Schema validation is now scoped per package directory, allowing different Viash versions to use their correct schemas (PR #39).
+
+* Automatically update schemas when `_viash.yaml` files are created, modified, or deleted (PR #39).
+
+## MAJOR CHANGES
+
+* `_viash.yaml` and `*.vsh.yaml` files in subdirectories are now properly detected and validated (PR #39).
+
+* Tests are now run from the correct package root directory, fixing issues with relative paths (PR #39).
+
+## MINOR CHANGES
+
+* Improved error handling when Viash is not installed (PR #39).
+
+* Added file system watcher for `_viash.yaml` changes to refresh test discovery (PR #39).
+
+* Removed unused Debug test profile (PR #39).
 
 # viash-vscode v0.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 * Automatically update schemas when `_viash.yaml` files are created, modified, or deleted (PR #39).
 
+* YAML parsing of project configs supporting Viash's `__merge__` operator for inheriting from other YAML files (PR #39).
+
+* Added unit tests for YAML merge functionality with comprehensive test coverage (PR #39).
+
+* Added CI workflow for running tests on pull requests (PR #39).
+
 ## MAJOR CHANGES
 
 * `_viash.yaml` and `*.vsh.yaml` files in subdirectories are now properly detected and validated (PR #39).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,27 @@
 {
   "name": "viash",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "viash",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "vscode-test-adapter-api": "^1.9.0",
-        "vscode-test-adapter-util": "^0.7.1"
+        "vscode-test-adapter-util": "^0.7.1",
+        "yaml": "^2.5.0"
       },
       "devDependencies": {
+        "@types/chai": "^5.0.1",
+        "@types/mocha": "^10.0.10",
         "@types/node": "~25.0.3",
         "@types/vscode": "^1.107.0",
         "@vscode/vsce": "^3.7.1",
+        "chai": "^5.1.2",
+        "mocha": "^11.0.1",
+        "ts-node": "^10.9.2",
         "typescript": "^5.9.3"
       },
       "engines": {
@@ -233,6 +239,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@isaacs/balanced-match": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
@@ -299,6 +318,34 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -335,6 +382,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@secretlint/config-creator": {
@@ -608,6 +666,59 @@
         "@textlint/ast-node-types": "15.5.0"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mocha": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.0.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
@@ -846,6 +957,32 @@
         "win32"
       ]
     },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -918,12 +1055,29 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
@@ -1049,6 +1203,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -1139,6 +1300,36 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1154,6 +1345,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/cheerio": {
@@ -1200,6 +1401,22 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
@@ -1207,6 +1424,62 @@
       "dev": true,
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/cockatiel": {
       "version": "3.2.1",
@@ -1265,6 +1538,13 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1331,6 +1611,19 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/decompress-response": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -1346,6 +1639,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-extend": {
@@ -1421,6 +1724,16 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dom-serializer": {
@@ -1638,6 +1951,29 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -1723,6 +2059,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -1788,6 +2151,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -1981,6 +2354,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
       }
     },
     "node_modules/hosted-git-info": {
@@ -2209,6 +2592,39 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-wsl": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
@@ -2405,6 +2821,22 @@
         "uc.micro": "^2.0.0"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -2468,6 +2900,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -2480,6 +2936,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/markdown-it": {
       "version": "14.1.0",
@@ -2632,6 +3095,159 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/mocha": {
+      "version": "11.7.5",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
+      "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^4.0.1",
+        "debug": "^4.3.5",
+        "diff": "^7.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^10.4.5",
+        "he": "^1.2.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^9.0.5",
+        "ms": "^2.1.3",
+        "picocolors": "^1.1.1",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^9.2.0",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1",
+        "yargs-unparser": "^2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/mocha/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/mocha/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2781,6 +3397,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-map": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
@@ -2892,6 +3540,16 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -2940,6 +3598,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/pend": {
@@ -3066,6 +3734,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -3156,6 +3834,30 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/require-from-string": {
@@ -3284,6 +3986,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
       }
     },
     "node_modules/shebang-command": {
@@ -3828,6 +4540,60 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -3977,6 +4743,13 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -4067,6 +4840,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/workerpool": {
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
+      "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
@@ -4214,12 +4994,82 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/yauzl": {
       "version": "2.10.0",
@@ -4240,6 +5090,29 @@
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -39,13 +39,19 @@
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
+    "test": "mocha -r ts-node/register 'src/**/*.test.ts'",
     "package": "vsce package",
     "publish": "vsce publish"
   },
   "devDependencies": {
+    "@types/chai": "^5.0.1",
+    "@types/mocha": "^10.0.10",
     "@types/node": "~25.0.3",
     "@types/vscode": "^1.107.0",
     "@vscode/vsce": "^3.7.1",
+    "chai": "^5.1.2",
+    "mocha": "^11.0.1",
+    "ts-node": "^10.9.2",
     "typescript": "^5.9.3"
   },
   "extensionDependencies": [
@@ -53,6 +59,7 @@
   ],
   "dependencies": {
     "vscode-test-adapter-api": "^1.9.0",
-    "vscode-test-adapter-util": "^0.7.1"
+    "vscode-test-adapter-util": "^0.7.1",
+    "yaml": "^2.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "nextflow",
     "testing"
   ],
-  "version": "0.2.2",
+  "version": "0.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/viash-io/viash-vscode.git"

--- a/src/activateViashSchema.ts
+++ b/src/activateViashSchema.ts
@@ -27,9 +27,9 @@ function getPackageGlob(pkg: ViashPackage, pattern: string): string {
   // Find which workspace folder contains this package
   for (const folder of workspaceFolders) {
     const folderPath = folder.uri.fsPath;
-    if (pkg.rootDir.startsWith(folderPath)) {
-      // Get relative path from workspace folder to package root
-      const relativePath = path.relative(folderPath, pkg.rootDir);
+    const relativePath = path.relative(folderPath, pkg.rootDir);
+    // Check if package is within this folder (relative path doesn't start with ..)
+    if (!relativePath.startsWith("..")) {
       if (relativePath === "") {
         // Package is at workspace root
         return pattern;

--- a/src/activateViashSchema.ts
+++ b/src/activateViashSchema.ts
@@ -110,6 +110,21 @@ async function updateSchemas(): Promise<void> {
       const configSchemaPath = getViashSchemaFile(version, "config");
       const packageSchemaPath = getViashSchemaFile(version, "package");
 
+      // Remove existing Viash schema entries to avoid stale mappings
+      for (const key of Object.keys(schemas)) {
+        const globs = schemas[key];
+        const isViashUrl = key.startsWith(VIASH_SCHEMA_URL_PREFIX);
+        const hasViashGlobs = Array.isArray(globs) && globs.some(glob => 
+          glob.includes("*.vsh.yaml") || 
+          glob.includes("*.vsh.yml") || 
+          glob.includes("_viash.yaml") || 
+          glob.includes("_viash.yml")
+        );
+        
+        if (isViashUrl || hasViashGlobs) {
+          delete schemas[key];
+        }
+      }
       if (configSchemaPath) {
         schemas[configSchemaPath] = ["**/*.vsh.yaml", "**/*.vsh.yml"];
       }

--- a/src/activateViashSchema.ts
+++ b/src/activateViashSchema.ts
@@ -57,6 +57,8 @@ export async function activateViashSchema(context: vscode.ExtensionContext) {
   context.subscriptions.push(watcher.onDidChange(() => updateSchemas()));
 }
 
+const VIASH_SCHEMA_URL_PREFIX = "https://raw.githubusercontent.com/viash-io/viash-schemas/";
+
 async function updateSchemas(): Promise<void> {
   // Find all Viash packages
   const packages = await findViashPackages();
@@ -64,6 +66,13 @@ async function updateSchemas(): Promise<void> {
   const config = vscode.workspace.getConfiguration("yaml");
   const schemas = config.get<Record<string, string[]>>("schemas") || {};
   const origSchemas = JSON.stringify(schemas);
+
+  // Remove existing Viash schema entries to avoid stale mappings
+  for (const key of Object.keys(schemas)) {
+    if (key.startsWith(VIASH_SCHEMA_URL_PREFIX)) {
+      delete schemas[key];
+    }
+  }
 
   // Build schema mappings scoped to each package
   const configSchemaToGlobs = new Map<string, string[]>();

--- a/src/activateViashSchema.ts
+++ b/src/activateViashSchema.ts
@@ -1,31 +1,140 @@
 import * as vscode from "vscode";
+import * as path from "path";
 import { getViashVersion } from "./getViashVersion";
 import { getViashSchemaFile } from "./getViashSchemaFile";
+import { findViashPackages, ViashPackage } from "./viash/findPackages";
 
-export async function activateViashSchema(context: vscode.ExtensionContext) {
-  const version = getViashVersion();
-  if (!version) {
-    return;
+/**
+ * Get the effective Viash version for a package.
+ * Uses viash_version from config, or falls back to running `viash --version`.
+ */
+function getPackageVersion(pkg: ViashPackage): string | undefined {
+  if (pkg.viashVersion) {
+    return pkg.viashVersion;
+  }
+  return getViashVersion(pkg.rootDir);
+}
+
+/**
+ * Get workspace-relative glob pattern for a package directory.
+ */
+function getPackageGlob(pkg: ViashPackage, pattern: string): string {
+  const workspaceFolders = vscode.workspace.workspaceFolders;
+  if (!workspaceFolders) {
+    return pattern;
   }
 
-  const configSchemaPath = getViashSchemaFile(version, "config");
-  const packageSchemaPath = getViashSchemaFile(version, "package");
+  // Find which workspace folder contains this package
+  for (const folder of workspaceFolders) {
+    const folderPath = folder.uri.fsPath;
+    if (pkg.rootDir.startsWith(folderPath)) {
+      // Get relative path from workspace folder to package root
+      const relativePath = path.relative(folderPath, pkg.rootDir);
+      if (relativePath === "") {
+        // Package is at workspace root
+        return pattern;
+      }
+      // Convert to forward slashes for glob pattern
+      const globPath = relativePath.split(path.sep).join("/");
+      return `${globPath}/${pattern}`;
+    }
+  }
+
+  return pattern;
+}
+
+export async function activateViashSchema(context: vscode.ExtensionContext) {
+  // Initial schema configuration
+  await updateSchemas();
+
+  // Watch for _viash.yaml changes to update schemas
+  const watcher = vscode.workspace.createFileSystemWatcher(
+    "**/_viash.{yaml,yml}"
+  );
+  context.subscriptions.push(watcher);
+  context.subscriptions.push(watcher.onDidCreate(() => updateSchemas()));
+  context.subscriptions.push(watcher.onDidDelete(() => updateSchemas()));
+  context.subscriptions.push(watcher.onDidChange(() => updateSchemas()));
+}
+
+async function updateSchemas(): Promise<void> {
+  // Find all Viash packages
+  const packages = await findViashPackages();
 
   const config = vscode.workspace.getConfiguration("yaml");
-  const schemas = config.get<any>("schemas") || {};
-  const origSchemas = { ...schemas };
-  
-  schemas[configSchemaPath] = ["*.vsh.yaml", "*.vsh.yml"];
-  schemas[packageSchemaPath] = ["_viash.yaml", "_viash.yml"];
+  const schemas = config.get<Record<string, string[]>>("schemas") || {};
+  const origSchemas = JSON.stringify(schemas);
+
+  // Build schema mappings scoped to each package
+  const configSchemaToGlobs = new Map<string, string[]>();
+  const packageSchemaToGlobs = new Map<string, string[]>();
+
+  for (const pkg of packages) {
+    const version = getPackageVersion(pkg);
+    if (!version) {
+      continue;
+    }
+
+    const configSchemaPath = getViashSchemaFile(version, "config");
+    const packageSchemaPath = getViashSchemaFile(version, "package");
+
+    if (!configSchemaPath || !packageSchemaPath) {
+      continue;
+    }
+
+    // Add globs scoped to this package's directory
+    const configGlobs = configSchemaToGlobs.get(configSchemaPath) || [];
+    configGlobs.push(getPackageGlob(pkg, "**/*.vsh.yaml"));
+    configGlobs.push(getPackageGlob(pkg, "**/*.vsh.yml"));
+    configSchemaToGlobs.set(configSchemaPath, configGlobs);
+
+    const packageGlobs = packageSchemaToGlobs.get(packageSchemaPath) || [];
+    packageGlobs.push(getPackageGlob(pkg, "_viash.yaml"));
+    packageGlobs.push(getPackageGlob(pkg, "_viash.yml"));
+    packageSchemaToGlobs.set(packageSchemaPath, packageGlobs);
+  }
+
+  // If no packages found, fall back to global patterns with installed version
+  if (packages.length === 0) {
+    const version = getViashVersion();
+    if (version) {
+      const configSchemaPath = getViashSchemaFile(version, "config");
+      const packageSchemaPath = getViashSchemaFile(version, "package");
+
+      if (configSchemaPath) {
+        schemas[configSchemaPath] = ["**/*.vsh.yaml", "**/*.vsh.yml"];
+      }
+      if (packageSchemaPath) {
+        schemas[packageSchemaPath] = ["**/_viash.yaml", "**/_viash.yml"];
+      }
+    }
+  } else {
+    // Apply scoped schemas
+    for (const [schemaPath, globs] of configSchemaToGlobs) {
+      schemas[schemaPath] = globs;
+    }
+    for (const [schemaPath, globs] of packageSchemaToGlobs) {
+      schemas[schemaPath] = globs;
+    }
+  }
 
   // Don't update if the schemas are the same
-  if (JSON.stringify(schemas) === JSON.stringify(origSchemas)) {
+  if (JSON.stringify(schemas) === origSchemas) {
     return;
   }
 
   // Update the schema setting
   config.update("schemas", schemas, vscode.ConfigurationTarget.Workspace);
-  vscode.window.showInformationMessage(
-    `Viash ${version} detected. Set schema to '${configSchemaPath}'.`
-  );
+
+  // Show appropriate message
+  const versions = [...new Set(packages.map(getPackageVersion).filter(Boolean))];
+  if (versions.length === 1) {
+    vscode.window.showInformationMessage(
+      `Viash ${versions[0]} schema configured for ${packages.length} package(s).`
+    );
+  } else if (versions.length > 1) {
+    vscode.window.showInformationMessage(
+      `Viash schemas configured for ${packages.length} package(s) with versions: ${versions.join(", ")}.`
+    );
+  }
 }

--- a/src/getViashSchemaFile.ts
+++ b/src/getViashSchemaFile.ts
@@ -3,9 +3,13 @@ import { getViashVersion } from "./getViashVersion";
 export function getViashSchemaFile(
   version: string | undefined = undefined,
   objectType: string = "config"
-): string {
+): string | undefined {
   if (!version) {
     version = getViashVersion();
+  }
+  
+  if (!version) {
+    return undefined;
   }
 
   return `https://raw.githubusercontent.com/viash-io/viash-schemas/refs/heads/main/json_schemas/${version}/${objectType}.schema.json`;

--- a/src/getViashVersion.ts
+++ b/src/getViashVersion.ts
@@ -13,7 +13,7 @@ export function getViashVersion(cwd?: string): string | undefined {
     });
     
     if (result.error) {
-      // viash command not found
+      // viash command not found - silent failure
       return undefined;
     }
     
@@ -25,7 +25,7 @@ export function getViashVersion(cwd?: string): string | undefined {
     const version = result.stdout.toString().trim().split(" ")[1];
     return version || undefined;
   } catch (error) {
-    vscode.window.showErrorMessage(`Error getting Viash version: ${error}`);
+    // Unexpected error - let caller decide whether to show message
     return undefined;
   }
 }

--- a/src/getViashVersion.ts
+++ b/src/getViashVersion.ts
@@ -1,15 +1,31 @@
 import * as vscode from "vscode";
 import * as cp from "child_process";
 
-export function getViashVersion(): string {
+/**
+ * Get the installed Viash version by running `viash --version`.
+ * @param cwd - Directory to run the command from. If provided, Viash may use
+ *              version management based on the project's _viash.yaml.
+ */
+export function getViashVersion(cwd?: string): string | undefined {
   try {
-    const { stdout } = cp.spawnSync("viash", ["--version"], {
-      cwd: vscode.workspace.workspaceFolders?.[0].uri.fsPath,
+    const result = cp.spawnSync("viash", ["--version"], {
+      cwd: cwd ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
     });
+    
+    if (result.error) {
+      // viash command not found
+      return undefined;
+    }
+    
+    if (result.status !== 0) {
+      return undefined;
+    }
+    
     // stdout format: 'viash <version> (c) <year> <author>'
-    return stdout.toString().trim().split(" ")[1];
+    const version = result.stdout.toString().trim().split(" ")[1];
+    return version || undefined;
   } catch (error) {
     vscode.window.showErrorMessage(`Error getting Viash version: ${error}`);
-    return "unknown";
+    return undefined;
   }
 }

--- a/src/viash/findPackages.ts
+++ b/src/viash/findPackages.ts
@@ -1,0 +1,89 @@
+import * as vscode from "vscode";
+import * as fs from "fs";
+import * as path from "path";
+
+export interface ViashPackage {
+  /** Absolute path to the _viash.yaml file */
+  configPath: string;
+  /** Absolute path to the directory containing _viash.yaml */
+  rootDir: string;
+  /** Package name from the config */
+  name?: string;
+  /** Viash version specified in the config */
+  viashVersion?: string;
+}
+
+/**
+ * Find all _viash.yaml files in the workspace and parse basic info from them.
+ */
+export async function findViashPackages(): Promise<ViashPackage[]> {
+  const packages: ViashPackage[] = [];
+
+  // Search for _viash.yaml files across all workspace folders
+  const files = await vscode.workspace.findFiles(
+    "**/_viash.{yaml,yml}",
+    "**/node_modules/**"
+  );
+
+  for (const file of files) {
+    const configPath = file.fsPath;
+    const rootDir = path.dirname(configPath);
+
+    try {
+      const content = fs.readFileSync(configPath, "utf-8");
+      const parsed = parseViashYaml(content);
+
+      packages.push({
+        configPath,
+        rootDir,
+        name: parsed.name,
+        viashVersion: parsed.viashVersion,
+      });
+    } catch (error) {
+      console.error(`Error reading ${configPath}:`, error);
+      // Still add the package even if we can't parse it
+      packages.push({
+        configPath,
+        rootDir,
+      });
+    }
+  }
+
+  return packages;
+}
+
+/**
+ * Simple YAML parser to extract name and viash_version fields.
+ * We use a simple regex approach to avoid adding a YAML parsing dependency.
+ */
+function parseViashYaml(content: string): {
+  name?: string;
+  viashVersion?: string;
+} {
+  const nameMatch = content.match(/^name:\s*(.+)$/m);
+  const versionMatch = content.match(/^viash_version:\s*(.+)$/m);
+
+  return {
+    name: nameMatch?.[1]?.trim().replace(/^["']|["']$/g, ""),
+    viashVersion: versionMatch?.[1]?.trim().replace(/^["']|["']$/g, ""),
+  };
+}
+
+/**
+ * Get unique viash versions from a list of packages.
+ * Returns versions sorted in descending order (newest first).
+ */
+export function getUniqueVersions(packages: ViashPackage[]): string[] {
+  const versions = new Set<string>();
+
+  for (const pkg of packages) {
+    if (pkg.viashVersion) {
+      versions.add(pkg.viashVersion);
+    }
+  }
+
+  return Array.from(versions).sort((a, b) => {
+    // Sort semver-like versions in descending order
+    return b.localeCompare(a, undefined, { numeric: true });
+  });
+}

--- a/src/viash/findPackages.ts
+++ b/src/viash/findPackages.ts
@@ -54,8 +54,7 @@ export async function findViashPackages(): Promise<ViashPackage[]> {
 }
 
 /**
- * Simple YAML parser to extract name and viash_version fields.
- * We use a simple regex approach to avoid adding a YAML parsing dependency.
+ * Parse Viash YAML to extract name and viash_version fields.
  */
 function parseViashYaml(content: string, baseDir: string, packageRoot: string): {
   name?: string;
@@ -73,13 +72,9 @@ function parseViashYaml(content: string, baseDir: string, packageRoot: string): 
 
     return { name, viashVersion };
   } catch (error) {
-    console.error("Failed to parse YAML with merge; falling back to regex:", error);
-    const nameMatch = content.match(/^name:\s*(.+)$/m);
-    const versionMatch = content.match(/^viash_version:\s*(.+)$/m);
-    return {
-      name: nameMatch?.[1]?.trim().replace(/^["']|["']$/g, ""),
-      viashVersion: versionMatch?.[1]?.trim().replace(/^["']|["']$/g, ""),
-    };
+    // If parsing fails, return empty - the package will still be added
+    // but without name/version information
+    return {};
   }
 }
 

--- a/src/viash/nsList.ts
+++ b/src/viash/nsList.ts
@@ -61,7 +61,8 @@ export async function nsList(packageRoot: string): Promise<Component[]> {
         let results: Component[] = [];
 
         try {
-          const parsed = stdout.trim() ? JSON.parse(stdout) : [];
+          const safeStdout = stdout ?? "";
+          const parsed = safeStdout.trim() ? JSON.parse(safeStdout) : [];
           results = parsed.map((x: NsListResult) => {
             const packagePrefix = x.package_config?.name
               ? `${x.package_config.name}/`

--- a/src/viash/yamlWithMerge.test.ts
+++ b/src/viash/yamlWithMerge.test.ts
@@ -1,0 +1,415 @@
+import { describe, it, before, after } from "mocha";
+import { expect } from "chai";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import { parseYamlWithMerge, readYamlWithMerge } from "./yamlWithMerge";
+
+describe("yamlWithMerge", () => {
+  let tempDir: string;
+
+  before(() => {
+    // Create a temporary directory for test files
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "viash-yaml-merge-test-"));
+  });
+
+  after(() => {
+    // Clean up temporary directory
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  describe("basic merge functionality", () => {
+    it("should parse YAML without merge", () => {
+      const content = `
+name: test-package
+viash_version: 0.9.0
+`;
+      const result = parseYamlWithMerge(content, tempDir, tempDir);
+      expect(result.name).to.equal("test-package");
+      expect(result.viash_version).to.equal("0.9.0");
+    });
+
+    it("should merge with a single file", () => {
+      // Create a base file to merge
+      const baseFile = path.join(tempDir, "base.yaml");
+      fs.writeFileSync(
+        baseFile,
+        `
+a: 1
+b: 2
+`
+      );
+
+      const content = `
+__merge__: base.yaml
+c: 3
+`;
+      const result = parseYamlWithMerge(content, tempDir, tempDir);
+      expect(result.a).to.equal(1);
+      expect(result.b).to.equal(2);
+      expect(result.c).to.equal(3);
+    });
+
+    it("should merge with multiple files", () => {
+      const file1 = path.join(tempDir, "obj1.yaml");
+      const file2 = path.join(tempDir, "obj2.yaml");
+      fs.writeFileSync(file1, "a:\n  - 1");
+      fs.writeFileSync(file2, "a:\n  - 2");
+
+      const content = `
+__merge__: [obj1.yaml, obj2.yaml]
+a:
+  - 3
+`;
+      const result = parseYamlWithMerge(content, tempDir, tempDir);
+      expect(result.a).to.deep.equal([1, 2, 3]);
+    });
+
+    it("should handle '.' placeholder for self", () => {
+      const baseFile = path.join(tempDir, "base-dot.yaml");
+      fs.writeFileSync(baseFile, "a: 1\nb: 2");
+
+      const content = `
+__merge__: [".", base-dot.yaml]
+a: 3
+`;
+      const result = parseYamlWithMerge(content, tempDir, tempDir);
+      // '.' comes first, then base-dot.yaml overrides, so we expect base-dot.yaml values
+      expect(result.a).to.equal(1);
+      expect(result.b).to.equal(2);
+    });
+
+    it("should append '.' if not explicitly specified", () => {
+      const baseFile = path.join(tempDir, "base-implicit.yaml");
+      fs.writeFileSync(baseFile, "a: 1");
+
+      const content = `
+__merge__: base-implicit.yaml
+a: 3
+b: 4
+`;
+      const result = parseYamlWithMerge(content, tempDir, tempDir);
+      // base-implicit.yaml comes first (a:1), then self (a:3, b:4)
+      expect(result.a).to.equal(3);
+      expect(result.b).to.equal(4);
+    });
+  });
+
+  describe("path resolution", () => {
+    it("should resolve paths starting with '/' relative to package root", () => {
+      const subDir = path.join(tempDir, "sub");
+      fs.mkdirSync(subDir, { recursive: true });
+
+      const rootFile = path.join(tempDir, "root-config.yaml");
+      fs.writeFileSync(rootFile, "root_value: from-root");
+
+      const content = `
+__merge__: /root-config.yaml
+local_value: from-local
+`;
+      // Current file is in subDir, but merge path starts with '/'
+      const result = parseYamlWithMerge(content, subDir, tempDir);
+      expect(result.root_value).to.equal("from-root");
+      expect(result.local_value).to.equal("from-local");
+    });
+
+    it("should resolve relative paths relative to current file", () => {
+      const subDir = path.join(tempDir, "nested");
+      fs.mkdirSync(subDir, { recursive: true });
+
+      const relFile = path.join(subDir, "relative.yaml");
+      fs.writeFileSync(relFile, "relative_value: from-relative");
+
+      const content = `
+__merge__: relative.yaml
+main_value: from-main
+`;
+      const result = parseYamlWithMerge(content, subDir, tempDir);
+      expect(result.relative_value).to.equal("from-relative");
+      expect(result.main_value).to.equal("from-main");
+    });
+
+    it("should handle nested directory structures", () => {
+      const dir1 = path.join(tempDir, "dir1");
+      const dir2 = path.join(tempDir, "dir1", "dir2");
+      fs.mkdirSync(dir1, { recursive: true });
+      fs.mkdirSync(dir2, { recursive: true });
+
+      const parentFile = path.join(dir1, "parent.yaml");
+      fs.writeFileSync(parentFile, "parent: true");
+
+      const content = `
+__merge__: ../parent.yaml
+child: true
+`;
+      const result = parseYamlWithMerge(content, dir2, tempDir);
+      expect(result.parent).to.equal(true);
+      expect(result.child).to.equal(true);
+    });
+  });
+
+  describe("nested and recursive merges", () => {
+    it("should handle nested __merge__ in child files", () => {
+      const grandparent = path.join(tempDir, "grandparent.yaml");
+      const parent = path.join(tempDir, "parent.yaml");
+
+      fs.writeFileSync(grandparent, "level: grandparent\nvalue: 1");
+      fs.writeFileSync(
+        parent,
+        `
+__merge__: grandparent.yaml
+level: parent
+value: 2
+`
+      );
+
+      const content = `
+__merge__: parent.yaml
+level: child
+value: 3
+`;
+      const result = parseYamlWithMerge(content, tempDir, tempDir);
+      expect(result.level).to.equal("child");
+      expect(result.value).to.equal(3);
+    });
+
+    it("should handle __merge__ at nested object levels", () => {
+      const baseConfig = path.join(tempDir, "base-nested.yaml");
+      fs.writeFileSync(
+        baseConfig,
+        `
+inner_value: from-base
+`
+      );
+
+      const content = `
+top_level: value
+nested:
+  __merge__: base-nested.yaml
+  local: data
+`;
+      const result = parseYamlWithMerge(content, tempDir, tempDir);
+      expect(result.top_level).to.equal("value");
+      expect(result.nested.inner_value).to.equal("from-base");
+      expect(result.nested.local).to.equal("data");
+    });
+
+    it("should handle __merge__ in arrays", () => {
+      const arrayItem = path.join(tempDir, "array-item.yaml");
+      fs.writeFileSync(arrayItem, "merged: true");
+
+      const content = `
+items:
+  - name: first
+  - __merge__: array-item.yaml
+    name: second
+`;
+      const result = parseYamlWithMerge(content, tempDir, tempDir);
+      expect(result.items).to.be.an("array");
+      expect(result.items[0].name).to.equal("first");
+      expect(result.items[1].merged).to.equal(true);
+      expect(result.items[1].name).to.equal("second");
+    });
+  });
+
+  describe("deep merge behavior", () => {
+    it("should deep merge nested objects", () => {
+      const base = path.join(tempDir, "base-deep.yaml");
+      fs.writeFileSync(
+        base,
+        `
+config:
+  a: 1
+  b: 2
+  nested:
+    x: 10
+`
+      );
+
+      const content = `
+__merge__: base-deep.yaml
+config:
+  b: 20
+  c: 3
+  nested:
+    y: 20
+`;
+      const result = parseYamlWithMerge(content, tempDir, tempDir);
+      expect(result.config.a).to.equal(1);
+      expect(result.config.b).to.equal(20);
+      expect(result.config.c).to.equal(3);
+      expect(result.config.nested.x).to.equal(10);
+      expect(result.config.nested.y).to.equal(20);
+    });
+
+    it("should concatenate arrays, not override them", () => {
+      const base = path.join(tempDir, "base-array.yaml");
+      fs.writeFileSync(base, "items:\n  - 1\n  - 2\n  - 3");
+
+      const content = `
+__merge__: base-array.yaml
+items:
+  - 4
+  - 5
+`;
+      const result = parseYamlWithMerge(content, tempDir, tempDir);
+      expect(result.items).to.deep.equal([1, 2, 3, 4, 5]);
+    });
+  });
+
+  describe("merge order", () => {
+    it("should apply merges in the specified order", () => {
+      const file1 = path.join(tempDir, "order1.yaml");
+      const file2 = path.join(tempDir, "order2.yaml");
+      const file3 = path.join(tempDir, "order3.yaml");
+
+      fs.writeFileSync(file1, "value: first\na: 1");
+      fs.writeFileSync(file2, "value: second\nb: 2");
+      fs.writeFileSync(file3, "value: third\nc: 3");
+
+      const content = `
+__merge__: [order1.yaml, order2.yaml, order3.yaml]
+value: final
+d: 4
+`;
+      const result = parseYamlWithMerge(content, tempDir, tempDir);
+      expect(result.value).to.equal("final");
+      expect(result.a).to.equal(1);
+      expect(result.b).to.equal(2);
+      expect(result.c).to.equal(3);
+      expect(result.d).to.equal(4);
+    });
+  });
+
+  describe("cycle detection", () => {
+    it("should prevent infinite loops from circular merges", () => {
+      const cycle1 = path.join(tempDir, "cycle1.yaml");
+      const cycle2 = path.join(tempDir, "cycle2.yaml");
+
+      fs.writeFileSync(
+        cycle1,
+        `
+__merge__: cycle2.yaml
+from_cycle1: true
+`
+      );
+      fs.writeFileSync(
+        cycle2,
+        `
+__merge__: cycle1.yaml
+from_cycle2: true
+`
+      );
+
+      const content = `
+__merge__: cycle1.yaml
+root: true
+`;
+      // Should not throw, should handle gracefully
+      const result = parseYamlWithMerge(content, tempDir, tempDir);
+      expect(result.root).to.equal(true);
+      // Depending on implementation, one of these should be true
+      expect(result.from_cycle1 || result.from_cycle2).to.be.true;
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle missing files gracefully", () => {
+      const content = `
+__merge__: nonexistent.yaml
+value: present
+`;
+      // Should not throw, should log error and continue
+      const result = parseYamlWithMerge(content, tempDir, tempDir);
+      expect(result.value).to.equal("present");
+    });
+
+    it("should handle invalid YAML in merged files gracefully", () => {
+      const invalidFile = path.join(tempDir, "invalid.yaml");
+      fs.writeFileSync(invalidFile, "one: foo\n/wqwqws");
+
+      const content = `
+__merge__: invalid.yaml
+value: present
+`;
+      // Should log error but continue with local values
+      const result = parseYamlWithMerge(content, tempDir, tempDir);
+      expect(result.value).to.equal("present");
+    });
+  });
+
+  describe("readYamlWithMerge", () => {
+    it("should read and merge from file", () => {
+      const baseFile = path.join(tempDir, "read-base.yaml");
+      fs.writeFileSync(baseFile, "base: value");
+
+      const mainFile = path.join(tempDir, "read-main.yaml");
+      fs.writeFileSync(
+        mainFile,
+        `
+__merge__: read-base.yaml
+main: value
+`
+      );
+
+      const result = readYamlWithMerge(mainFile, tempDir);
+      expect(result.base).to.equal("value");
+      expect(result.main).to.equal("value");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty merge spec", () => {
+      const content = `
+__merge__: []
+value: test
+`;
+      const result = parseYamlWithMerge(content, tempDir, tempDir);
+      expect(result.value).to.equal("test");
+    });
+
+    it("should handle null values", () => {
+      const base = path.join(tempDir, "null-base.yaml");
+      fs.writeFileSync(base, "a: null\nb: 2");
+
+      const content = `
+__merge__: null-base.yaml
+c: 3
+`;
+      const result = parseYamlWithMerge(content, tempDir, tempDir);
+      expect(result.a).to.be.null;
+      expect(result.b).to.equal(2);
+      expect(result.c).to.equal(3);
+    });
+
+    it("should preserve types correctly", () => {
+      const base = path.join(tempDir, "types-base.yaml");
+      fs.writeFileSync(
+        base,
+        `
+string: "text"
+number: 42
+boolean: true
+array:
+  - 1
+  - 2
+  - 3
+object:
+  key: value
+`
+      );
+
+      const content = `
+__merge__: types-base.yaml
+`;
+      const result = parseYamlWithMerge(content, tempDir, tempDir);
+      expect(result.string).to.be.a("string");
+      expect(result.number).to.be.a("number");
+      expect(result.boolean).to.be.a("boolean");
+      expect(result.array).to.be.an("array");
+      expect(result.object).to.be.an("object");
+    });
+  });
+});

--- a/src/viash/yamlWithMerge.ts
+++ b/src/viash/yamlWithMerge.ts
@@ -1,0 +1,180 @@
+/**
+ * YAML parsing with __merge__ support, based on Viash's RichJson.inherit() implementation.
+ * 
+ * Reference: https://github.com/viash-io/viash/blob/main/src/main/scala/io/viash/helpers/circe/RichJson.scala
+ * 
+ * Supports:
+ *
+ * - Single string or array of strings for __merge__
+ * - '.' placeholder representing the current document
+ * - Paths starting with '/' are relative to package root
+ * - Other paths are relative to the current YAML file
+ * - Recursive merging at any nesting level
+ * - Deep merge of objects, concatenation of arrays
+ * - Cycle detection to prevent infinite loops
+ * 
+ * Note: This is a simplified implementation for the purpose of this VSCode plugin.
+ * It differs from Viash's strict implementation in several ways:
+ *
+ * - Always strips __merge__ from output (no stripInherits parameter)
+ * - Silently filters invalid merge specs instead of throwing exceptions
+ * - No validation for deprecated __includes__ field
+ * - Uses simple file path resolution instead of URI handling
+ * 
+ * These differences are acceptable since we're parsing for content reading, not viash build/run.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { parse as yamlParse } from "yaml";
+
+export function parseYamlWithMerge(
+  content: string,
+  baseDir: string,
+  packageRoot: string
+): any {
+  const doc = yamlParse(content) ?? {};
+  return resolveMerge(doc, baseDir, packageRoot);
+}
+
+export function readYamlWithMerge(entryFile: string, packageRoot: string): any {
+  const content = fs.readFileSync(entryFile, "utf-8");
+  return parseYamlWithMerge(content, path.dirname(entryFile), packageRoot);
+}
+
+function resolveMerge(
+  doc: any,
+  baseDir: string,
+  packageRoot: string,
+  seen: Set<string> = new Set()
+): any {
+  // Arrays and non-objects: just recurse into nested values
+  if (!isPlainObject(doc)) {
+    return recurseNested(doc, baseDir, packageRoot, seen);
+  }
+
+  const { __merge__, ...current } = doc || {};
+
+  // Build list of sources, ensuring '.' (self) is included once at the end if not specified
+  let sources = normalizeMergeSpec(__merge__);
+  const hasSelf = sources.includes(".");
+  if (!hasSelf) {
+    sources = [...sources, "."];
+  }
+
+  // Prepare a version of current with nested merges resolved as well
+  const selfResolved = recurseNested(current, baseDir, packageRoot, seen);
+
+  // Merge all sources in order
+  let merged: any = {};
+  for (const src of sources) {
+    if (src === ".") {
+      merged = deepMerge(merged, selfResolved);
+      continue;
+    }
+
+    const absPath = resolveSourcePath(src, baseDir, packageRoot);
+    if (!absPath) {
+      // Could not resolve path
+      continue;
+    }
+    if (seen.has(absPath)) {
+      continue; // prevent cycles
+    }
+    try {
+      const yamlText = fs.readFileSync(absPath, "utf-8");
+      seen.add(absPath);
+      const childDoc = yamlParse(yamlText) ?? {};
+      const childEffective = resolveMerge(
+        childDoc,
+        path.dirname(absPath),
+        packageRoot,
+        seen
+      );
+      merged = deepMerge(merged, childEffective);
+    } catch (e) {
+      // Note: Viash throws ConfigYamlException for parse errors.
+      // We silently skip failed merges for graceful IDE operation.
+      // This allows partial content to be used even if some merge targets are missing/invalid.
+    }
+  }
+
+  return merged;
+}
+
+function recurseNested(
+  value: any,
+  baseDir: string,
+  packageRoot: string,
+  seen: Set<string>
+): any {
+  if (isPlainObject(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([k, v]) => [
+        k,
+        isPlainObject(v) || Array.isArray(v)
+          ? resolveMerge(v, baseDir, packageRoot, seen)
+          : v,
+      ])
+    );
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) =>
+      isPlainObject(v) || Array.isArray(v)
+        ? resolveMerge(v, baseDir, packageRoot, seen)
+        : v
+    );
+  }
+  return value;
+}
+
+function resolveSourcePath(
+  src: string,
+  baseDir: string,
+  packageRoot: string
+): string | null {
+  if (src.startsWith("/")) {
+    // Relative to project config root
+    const rel = src.replace(/^\/+/, "");
+    return path.join(packageRoot, rel);
+  }
+  // Relative to current YAML file
+  return path.join(baseDir, src);
+}
+
+function normalizeMergeSpec(spec: any): string[] {
+  // Note: Viash throws ConfigParserMergeException for invalid types.
+  // We silently filter non-strings for graceful IDE parsing.
+  if (!spec) return [];
+  if (typeof spec === "string") return [spec];
+  if (Array.isArray(spec)) return spec.filter((x) => typeof x === "string");
+  return [];
+}
+
+function deepMerge(target: any, source: any): any {
+  if (isPlainObject(target) && isPlainObject(source)) {
+    const out: any = { ...target };
+    for (const key of Object.keys(source)) {
+      const tVal = out[key];
+      const sVal = source[key];
+      if (isPlainObject(tVal) && isPlainObject(sVal)) {
+        out[key] = deepMerge(tVal, sVal);
+      } else if (Array.isArray(tVal) && Array.isArray(sVal)) {
+        out[key] = deepMerge(tVal, sVal);
+      } else {
+        out[key] = sVal;
+      }
+    }
+    return out;
+  }
+  // If both are arrays, concatenate them
+  if (Array.isArray(target) && Array.isArray(source)) {
+    return [...target, ...source];
+  }
+  // Otherwise, source overrides target
+  return source;
+}
+
+function isPlainObject(val: any): val is Record<string, any> {
+  return !!val && typeof val === "object" && !Array.isArray(val);
+}

--- a/src/viashTestAdapter.ts
+++ b/src/viashTestAdapter.ts
@@ -3,10 +3,10 @@ import * as cp from "child_process";
 import * as util from "util";
 import { Log } from "vscode-test-adapter-util";
 import { Component, nsList } from "./viash/nsList";
+import { findViashPackages } from "./viash/findPackages";
 
 export function activateViashTestController(context: vscode.ExtensionContext) {
-  const workspaceFolder = (vscode.workspace.workspaceFolders || [])[0];
-  if (!workspaceFolder) {
+  if (!vscode.workspace.workspaceFolders?.length) {
     // No open workspace, don't activate
     return;
   }
@@ -17,75 +17,71 @@ export function activateViashTestController(context: vscode.ExtensionContext) {
   );
   context.subscriptions.push(controller);
 
-  const adapter = new ViashTestAdapter(workspaceFolder, controller);
+  const adapter = new ViashTestAdapter(controller);
   context.subscriptions.push(adapter);
 
-  // Initial load (important for first activation, and handles cases where the Test Explorer isn't immediately visible)
+  // Initial load
   adapter.load();
+}
+
+/** Map from test item ID to component info for running tests */
+interface TestItemData {
+  component: Component;
 }
 
 class ViashTestAdapter {
   private disposables: { dispose(): void }[] = [];
   private runningTestProcess?: cp.ChildProcess;
   private isLoading = false;
+  /** Store component data for each test item */
+  private testItemData = new Map<string, TestItemData>();
+  private log: Log;
 
-  constructor(
-    public readonly workspace: vscode.WorkspaceFolder,
-    private readonly controller: vscode.TestController,
-    private readonly log: Log = new Log(
-      "viash",
-      workspace,
-      "Viash Test Adapter Log"
-    )
-  ) {
-    this.disposables.push(
-      vscode.workspace.onDidChangeConfiguration((configChange) => {
-        if (
-          configChange.affectsConfiguration(
-            "viash.testFiles",
-            this.workspace.uri
-          )
-        ) {
-          this.load();
-        }
-      })
-    );
+  constructor(private readonly controller: vscode.TestController) {
+    // Use first workspace folder for logging (Log requires a workspace folder)
+    const firstWorkspace = vscode.workspace.workspaceFolders![0];
+    this.log = new Log("viash", firstWorkspace, "Viash Test Adapter Log");
 
+    // Watch for _viash.yaml and *.vsh.yaml changes
     this.disposables.push(
       vscode.workspace.onDidSaveTextDocument((document) => {
-        if (this.isViashConfigFile(document.uri)) {
+        if (this.isViashFile(document.uri)) {
           this.load();
         }
       })
     );
 
-    // Create Test Run Profiles
+    // Watch for file creation/deletion
+    const watcher = vscode.workspace.createFileSystemWatcher(
+      "**/{_viash.yaml,_viash.yml,*.vsh.yaml,*.vsh.yml}"
+    );
+    this.disposables.push(watcher);
+    this.disposables.push(watcher.onDidCreate(() => this.load()));
+    this.disposables.push(watcher.onDidDelete(() => this.load()));
+
+    // Create Test Run Profile
     this.controller.createRunProfile(
       "Run",
       vscode.TestRunProfileKind.Run,
-      (request, token) => this.runHandler(false, request, token)
-    );
-    this.controller.createRunProfile(
-      "Debug",
-      vscode.TestRunProfileKind.Debug,
-      (request, token) => this.runHandler(true, request, token)
+      (request, token) => this.runHandler(request, token)
     );
 
     // Set up the resolveHandler
     this.controller.resolveHandler = async (test) => {
       if (!test) {
-        // Initial load or refresh of all tests.
-        await this.load();
-      } else {
-        // Potentially handle expanding individual test items if needed.
-        // For now, we re-parse the whole thing on changes to be safe. Could optimize.
         await this.load();
       }
     };
   }
 
-  private isViashConfigFile(uri: vscode.Uri): boolean {
-    return uri.fsPath.endsWith(".vsh.yaml");
+  private isViashFile(uri: vscode.Uri): boolean {
+    const path = uri.fsPath;
+    return (
+      path.endsWith(".vsh.yaml") ||
+      path.endsWith(".vsh.yml") ||
+      path.endsWith("_viash.yaml") ||
+      path.endsWith("_viash.yml")
+    );
   }
 
   async load(): Promise<void> {
@@ -93,14 +89,11 @@ class ViashTestAdapter {
 
     this.isLoading = true;
     this.log.info("Loading Viash tests...");
+    this.testItemData.clear();
 
     try {
-      const suite = await this.loadSuite();
-      if (suite) {
-        this.controller.items.replace(suite);
-      } else {
-        this.controller.items.replace([]);
-      }
+      const items = await this.loadAllPackages();
+      this.controller.items.replace(items);
       this.log.info("Viash tests loaded.");
     } catch (e) {
       this.log.error("Error loading Viash tests:", e);
@@ -110,13 +103,47 @@ class ViashTestAdapter {
     }
   }
 
-  private async getViashConfigs() {
-    return await nsList(this.workspace.uri.fsPath);
+  private async loadAllPackages(): Promise<vscode.TestItem[]> {
+    const packages = await findViashPackages();
+
+    if (packages.length === 0) {
+      return [];
+    }
+
+    // Load components from each package
+    const allComponents: Component[] = [];
+
+    for (const pkg of packages) {
+      try {
+        const components = await nsList(pkg.rootDir);
+        allComponents.push(...components);
+      } catch (e) {
+        this.log.error(`Error loading package at ${pkg.rootDir}:`, e);
+        // Continue with other packages
+      }
+    }
+
+    if (allComponents.length === 0) {
+      return [];
+    }
+
+    // Build hierarchical test structure
+    return this.buildTestHierarchy(allComponents);
+  }
+
+  private buildTestHierarchy(components: Component[]): vscode.TestItem[] {
+    // Group by full path: package/namespace/component
+    const arr = components.map((c) => {
+      const keys = c.fullName.split("/").slice(0, -1);
+      return { keys, component: c };
+    });
+
+    return this.createNestedSuite(arr);
   }
 
   private createNestedSuite(
     arr: { keys: string[]; component: Component }[]
-  ): (vscode.TestItem | vscode.TestItem)[] {
+  ): vscode.TestItem[] {
     const currentComponents = arr
       .filter((c) => c.keys.length === 0)
       .map((c) => c.component);
@@ -125,6 +152,7 @@ class ViashTestAdapter {
       arr.filter((c) => c.keys.length > 0),
       (c) => c.keys[0]
     );
+
     const namespaceSuites: vscode.TestItem[] = Object.entries(
       groupedNsComponents
     ).map(([key, value]) => {
@@ -140,33 +168,19 @@ class ViashTestAdapter {
     });
 
     const componentTests: vscode.TestItem[] = currentComponents.map((c) => {
-      const testUri = vscode.Uri.joinPath(
-        this.workspace.uri,
-        c.build_info.config
-      );
-      return this.controller.createTestItem(c.fullName, c.name, testUri);
+      const testUri = vscode.Uri.file(c.absoluteConfigPath);
+      const testItem = this.controller.createTestItem(c.fullName, c.name, testUri);
+
+      // Store component data for test execution
+      this.testItemData.set(c.fullName, { component: c });
+
+      return testItem;
     });
 
     return [...namespaceSuites, ...componentTests];
   }
 
-  private async loadSuite(): Promise<vscode.TestItem[] | undefined> {
-    const viashConfigs = await this.getViashConfigs();
-
-    if (viashConfigs.length === 0) {
-      return undefined;
-    }
-
-    const arr = viashConfigs.map((c) => {
-      const keys = c.fullName.split("/").slice(0, -1);
-      return { keys, component: c };
-    });
-
-    return this.createNestedSuite(arr);
-  }
-
   async runHandler(
-    shouldDebug: boolean,
     request: vscode.TestRunRequest,
     token: vscode.CancellationToken
   ): Promise<void> {
@@ -192,7 +206,7 @@ class ViashTestAdapter {
         // It's a test case, run it
         await this.runTest(test, run, token);
       } else {
-        // It might be a suite, add children to queue
+        // It's a suite, add children to queue
         test.children.forEach((child) => queue.push(child));
       }
     }
@@ -207,17 +221,26 @@ class ViashTestAdapter {
     run.started(testItem);
     const start = Date.now();
 
+    const data = this.testItemData.get(testItem.id);
+    if (!data) {
+      run.failed(
+        testItem,
+        new vscode.TestMessage("Component data not found"),
+        Date.now() - start
+      );
+      return;
+    }
+
     try {
-      const process = cp.spawn("viash", ["test", testItem.uri!.path], {
-        cwd: this.workspace.uri.fsPath,
+      // Run viash test from the package root directory
+      const process = cp.spawn("viash", ["test", data.component.absoluteConfigPath], {
+        cwd: data.component.packageRoot,
       });
       this.runningTestProcess = process;
 
-      let stdout = "";
       let stderr = "";
 
       process.stdout?.on("data", (data) => {
-        stdout += data;
         run.appendOutput(
           data.toString().replace(/\n/g, "\r\n"),
           undefined,
@@ -242,7 +265,11 @@ class ViashTestAdapter {
       });
 
       if (code !== 0) {
-        run.failed(testItem, new vscode.TestMessage(stderr), Date.now() - start);
+        run.failed(
+          testItem,
+          new vscode.TestMessage(stderr || `Test exited with code ${code}`),
+          Date.now() - start
+        );
         return;
       }
 
@@ -250,7 +277,11 @@ class ViashTestAdapter {
     } catch (error) {
       const err = error as Error;
       this.log.error("Test failed:", testItem.id, err);
-      run.failed(testItem, new vscode.TestMessage(err.message), Date.now() - start);
+      run.failed(
+        testItem,
+        new vscode.TestMessage(err.message),
+        Date.now() - start
+      );
     } finally {
       this.runningTestProcess = undefined;
     }

--- a/src/viashTestAdapter.ts
+++ b/src/viashTestAdapter.ts
@@ -38,9 +38,8 @@ class ViashTestAdapter {
   private log: Log;
 
   constructor(private readonly controller: vscode.TestController) {
-    // Use first workspace folder for logging (Log requires a workspace folder)
-    const firstWorkspace = vscode.workspace.workspaceFolders![0];
-    this.log = new Log("viash", firstWorkspace, "Viash Test Adapter Log");
+    // Log is used for debugging
+    this.log = new Log("viash", undefined, "Viash Test Adapter Log");
 
     // Watch for _viash.yaml and *.vsh.yaml changes
     this.disposables.push(


### PR DESCRIPTION
## NEW FUNCTIONALITY

* Support for multiple Viash packages in a workspace, each with its own `viash_version`.

* Schema validation is now scoped per package directory, allowing different Viash versions to use their correct schemas.

* Automatically update schemas when `_viash.yaml` files are created, modified, or deleted.

* YAML parsing of project configs supporting Viash's `__merge__` operator for inheriting from other YAML files.

* Added unit tests for YAML merge functionality with comprehensive test coverage.

* Added CI workflow for running tests on pull requests.

## MAJOR CHANGES

* `_viash.yaml` and `*.vsh.yaml` files in subdirectories are now properly detected and validated.

* Tests are now run from the correct package root directory, fixing issues with relative paths.

## MINOR CHANGES

* Improved error handling when Viash is not installed.

* Added file system watcher for `_viash.yaml` changes to refresh test discovery.

* Removed unused Debug test profile.